### PR TITLE
Automate version bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Publish package on new release
 
 on:
-  release:
-    types: [published]
+  push
+  # release:
+  #   types: [published]
 
 jobs:
   main:
@@ -12,7 +13,7 @@ jobs:
         with: 
           token: ${{secrets.PAT}}
       - run: |
-          yarn version --minor
+          yarn version --patch
           git config user.name sahil-shubham
           git config user.email sahil.shubham2000@gmail.com
           git add .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
         with: 
           token: ${{secrets.PAT}}
       - run: |
-          yarn version --patch
           git config user.name sahil-shubham
           git config user.email sahil.shubham2000@gmail.com
+          yarn version --patch
           git add .
           git commit -m "version bump;" 
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with: 
+          token: ${{secrets.PAT}}
+      - run: |
+          yarn version --minor
+          git config user.name sahil-shubham
+          git config user.email sahil.shubham2000@gmail.com
+          git add .
+          git commit -m "version bump;" 
+          git push
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
           git config user.name sahil-shubham
           git config user.email sahil.shubham2000@gmail.com
           yarn version --patch
-          git add .
-          git commit -m "version bump;" 
           git push
       - uses: actions/setup-node@v2
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@felvin-search/apps",
   "license": "MIT",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@felvin-search/apps",
   "license": "MIT",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@felvin-search/apps",
   "license": "MIT",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## TODO
- [ ] Change the action to on push and check if the commit happens and the package is published with newer version
- [ ] Change back to on release


- (Just a thought) should we take version from the github release or `yarn version  --patch` is good? 