### PR TITLE
fix: excluded node_modules for babel_loader to fix setup issue on windows

### DIFF
--- a/packages/sandbox/webpack.config.js
+++ b/packages/sandbox/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     rules: [
       {
         test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
         use: {
           loader: "babel-loader",
           options: {


### PR DESCRIPTION
This fixes #146 