### PR TITLE
Fixed overflow in json formatter

### DIFF
--- a/apps/json-formatter/src/App.tsx
+++ b/apps/json-formatter/src/App.tsx
@@ -50,6 +50,7 @@ const JSONContainer = styled.div`
   font-family: inherit;
   font-size: inherit;
   min-height: 50px;
+  overflow-x: scroll;
 
   &:focus,
   &:active {


### PR DESCRIPTION
## Fixes Issue

#268 

## Changes Made 

Added overflow-x equal to scroll css property to avoid overflowing text from outside the container

## Screenshot
![13](https://user-images.githubusercontent.com/71957423/146236473-6ab30a32-4dda-416b-a8ad-384d58853a90.JPG)
