### PR TITLE
Add cheat.sh app

### DIFF
--- a/apps/cheat-sh/package.json
+++ b/apps/cheat-sh/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@felvin-community/cheat-sh",
+  "version": "1.0.0",
+  "license": "MIT",
+  "main": "./src/index.ts",
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.cjs.js",
+    "types": "./dist/index.d.ts"
+  },
+  "scripts": {
+    "build": "felvin-cli build:app"
+  },
+  "dependencies": {
+    "@felvin-search/core": "^1.0.0"
+  },
+  "devDependencies": {
+    "@felvin-search/cli": "^1.0.0",
+    "@types/react": "^17.0.0",
+    "@types/styled-components": "^5.1.11",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "styled-components": "^5.3.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "styled-components": ">= 5"
+  }
+}

--- a/apps/cheat-sh/src/App.jsx
+++ b/apps/cheat-sh/src/App.jsx
@@ -53,7 +53,7 @@ const Container = styled.div`
 function Component({ data }) {
   // console.log(data.keys())
   console.log(data)
-  const markup = {"__html": data["data"]}
+  const markup = {"__html": data["html"]}
   return (
     <Container dangerouslySetInnerHTML={markup}>
 
@@ -81,8 +81,12 @@ const getSnippet = async (query) => {
 // This where you can process the query and try to convert it into some meaningful data.
 const queryToData = async ({ query }) => {
   console.log("Inside Cheat.sh app")
-  const data = await getSnippet(query)
-  return {data};
+  const html = await getSnippet(query)
+  if(!html.includes("Unknown topic")){
+    return {html};
+  } else {
+    return;
+  }
 }
 
 export { queryToData, Component };

--- a/apps/cheat-sh/src/App.jsx
+++ b/apps/cheat-sh/src/App.jsx
@@ -1,0 +1,88 @@
+import React from "react";
+import styled from "styled-components";
+import { isTriggered } from "@felvin-search/core";
+
+//------------Styled Components-------------
+// If you're unfamiliar with styled components
+// start here https://styled-components.com/docs/basics#getting-started
+
+/*
+body {
+    background: black;
+    color: #bbbbbb;
+}
+.pre,
+pre {
+/*    font-family: source_code_proregular; */
+
+/*
+font-family: Courier New,Courier,Lucida Sans Typewriter,Lucida Typewriter,monospace;
+font-size: 70%;
+*/
+
+/*font-family: Lucida Console,Lucida Sans Typewriter,monaco,Bitstream Vera Sans Mono,monospace; */
+/*Droid Sans Mono*/
+// font-family: "DejaVu Sans Mono", Menlo, "Lucida Sans Typewriter", "Lucida Console", monaco, "Bitstream Vera Sans Mono", monospace;
+// /*font-family: bitstream_vera_sans_monoroman;*/
+// font-size: 75%;
+// }
+
+// input[type="text"]{
+//     border: none;
+//     background: transparent;
+//     color: #bbbbbb;
+// }
+
+
+// */
+const Container = styled.div`
+  background: black;
+  color: #bbbbbb;
+  justify-content: center;
+  align-items: center;
+  .pre {
+    font-family: Courier New,Courier,Lucida Sans Typewriter,Lucida Typewriter,monospace;
+    font-size: 70%
+  }
+`;
+
+//=========================================
+
+// Your UI logic goes here.
+// `data` prop is exactly what is returned by queryToData.
+function Component({ data }) {
+  // console.log(data.keys())
+  console.log(data)
+  const markup = {"__html": data["data"]}
+  return (
+    <Container dangerouslySetInnerHTML={markup}>
+
+    </Container>
+  );
+}
+
+const getSnippet = async (query) => {
+  // return "Yolo"
+  const response = await fetch(`http://167.172.16.188:8002/${query}`);
+  if(response.ok){
+    console.log("Got output from cht.sh")
+
+    const data = await response.text()
+    return data;
+  } else {
+    console.log("Didn't get output from cht.sh")
+    return;
+  }
+
+}
+
+//=========================================
+
+// This where you can process the query and try to convert it into some meaningful data.
+const queryToData = async ({ query }) => {
+  console.log("Inside Cheat.sh app")
+  const data = await getSnippet("css+center+div")
+  return {data};
+}
+
+export { queryToData, Component };

--- a/apps/cheat-sh/src/App.jsx
+++ b/apps/cheat-sh/src/App.jsx
@@ -81,7 +81,7 @@ const getSnippet = async (query) => {
 // This where you can process the query and try to convert it into some meaningful data.
 const queryToData = async ({ query }) => {
   console.log("Inside Cheat.sh app")
-  const data = await getSnippet("css+center+div")
+  const data = await getSnippet(query)
   return {data};
 }
 

--- a/apps/cheat-sh/src/App.jsx
+++ b/apps/cheat-sh/src/App.jsx
@@ -40,6 +40,7 @@ const Container = styled.div`
   color: #bbbbbb;
   justify-content: center;
   align-items: center;
+  padding: 2rem;
   .pre {
     font-family: Courier New,Courier,Lucida Sans Typewriter,Lucida Typewriter,monospace;
     font-size: 70%

--- a/apps/cheat-sh/src/index.ts
+++ b/apps/cheat-sh/src/index.ts
@@ -1,0 +1,14 @@
+import { InstantApp } from "@felvin-search/core";
+import { Component, queryToData } from "./App";
+
+const App: InstantApp = {
+  id: "@felvin-community/cheat-sh",
+  name: "cheatsheet",
+  description: "Cheatsheet for programming tasks",
+  queryToData,
+  Component,
+  // screenshotPath: "./files/screenshot.png",
+  // exampleSearchQueries: [],
+};
+
+export default App;

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -25,6 +25,7 @@
     "@felvin-community/async-api-validator": "^1.59.0",
     "@felvin-community/bouncy-ball": "^1.61.0",
     "@felvin-community/capitals": "^1.61.0",
+    "@felvin-community/cheat-sh": "^1.0.0",
     "@felvin-community/code-reference": "^1.30.0",
     "@felvin-community/color-picker": "^1.54.0",
     "@felvin-community/compressify": "^1.52.0",

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -1,3 +1,4 @@
+import CheatSh from "@felvin-community/cheat-sh";
 import Tldr from "@felvin-community/tldr";
 import ConvertToRoman from "@felvin-community/convert-to-roman";
 import HttpStatusCodes from "@felvin-community/http-status-codes";
@@ -63,6 +64,7 @@ import CourierTracker from "@felvin-community/courier-tracker";
 import YamlToJson from "@felvin-community/yaml-to-json"
 
 const allApps = [
+  CheatSh,
   Tldr,
   YamlToJson,
   ConvertToRoman,

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -64,7 +64,6 @@ import CourierTracker from "@felvin-community/courier-tracker";
 import YamlToJson from "@felvin-community/yaml-to-json"
 
 const allApps = [
-  CheatSh,
   Tldr,
   YamlToJson,
   ConvertToRoman,
@@ -128,6 +127,7 @@ const allApps = [
   Tetris,
   CourierTracker,
   TvShows,
+  CheatSh,
 ];
 
 export default allApps;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,6 +1599,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@felvin-community/cheat-sh@^1.0.0, @felvin-community/cheat-sh@workspace:apps/cheat-sh":
+  version: 0.0.0-use.local
+  resolution: "@felvin-community/cheat-sh@workspace:apps/cheat-sh"
+  dependencies:
+    "@felvin-search/cli": ^1.0.0
+    "@felvin-search/core": ^1.0.0
+    "@types/react": ^17.0.0
+    "@types/styled-components": ^5.1.11
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    styled-components: ^5.3.0
+  peerDependencies:
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    styled-components: ">= 5"
+  languageName: unknown
+  linkType: soft
+
 "@felvin-community/code-reference@^1.30.0, @felvin-community/code-reference@workspace:apps/code-reference":
   version: 0.0.0-use.local
   resolution: "@felvin-community/code-reference@workspace:apps/code-reference"
@@ -2714,6 +2732,7 @@ __metadata:
     "@felvin-community/async-api-validator": ^1.59.0
     "@felvin-community/bouncy-ball": ^1.61.0
     "@felvin-community/capitals": ^1.61.0
+    "@felvin-community/cheat-sh": ^1.0.0
     "@felvin-community/code-reference": ^1.30.0
     "@felvin-community/color-picker": ^1.54.0
     "@felvin-community/compressify": ^1.52.0


### PR DESCRIPTION
![Screenshot 2022-02-17 at 11 24 07 PM](https://user-images.githubusercontent.com/2477788/154617285-e63423e0-3fae-433f-be88-27117d8867de.png)


[Cheat.sh](https://github.com/chubin/cheat.sh) is the most comprehensive cheatsheet tool available online, it combines data from multiple sources including, tldr, rosettacode and stackoverflow to give you snippets for pretty much any programming task you might want to do.

TODO:

**Improve the UI/UX**
- [x] Add more padding
- [ ] Give a copy button
- [ ] Either remove the the twitter link in bottom or make it appear properly.

**Server**
- [ ] Deploy cheat.sh to cht.felvin.com (Couldn't use cht.sh because it doesn't allow Cross Origin Requests
- [x] Make the server return 404 in case there isn't a good cheatsheet to display