### PR TITLE
fix: currency conversion

### DIFF
--- a/apps/currency-convertor/src/App.jsx
+++ b/apps/currency-convertor/src/App.jsx
@@ -231,7 +231,11 @@ const parseConversionString = (query) => {
     } else if (tokens.length === 4) {
       try {
         const amount = parseFloat(tokens[0]);
-        return { amount, from: tokens[1], to: tokens[3] };
+        return {
+          amount,
+          from: !!amount ? tokens[1] : tokens.slice(0, 2).join(" "),
+          to: tokens[3],
+        };
       } catch {
         return null;
       }

--- a/apps/currency-convertor/src/App.jsx
+++ b/apps/currency-convertor/src/App.jsx
@@ -222,25 +222,18 @@ const parseConversionString = (query) => {
   if (normalizedQuery.includes(" TO ") || normalizedQuery.includes(" IN ")) {
     // The regex passed to the 1st split (/([0-9.]+)/) splits a string around a number (like "word12.3word" -> ["word", "12.3", "word"])
     const tokens = normalizedQuery
-      .split(/([0-9.]+)/)
-      .join(" ")
-      .split(" ")
+      .split(/ ?([0-9.]+) ?/)
       .filter((s) => s !== "");
-    if (tokens.length === 3) {
-      return { amount: 1, from: tokens[0], to: tokens[2] };
-    } else if (tokens.length === 4) {
-      try {
-        const amount = parseFloat(tokens[0]);
-        return {
-          amount,
-          from: !!amount ? tokens[1] : tokens.slice(0, 2).join(" "),
-          to: tokens[3],
-        };
-      } catch {
-        return null;
-      }
+    if (tokens.length === 1) {
+      let [from, to] = tokens[0].split(" TO " || " IN ");
+      return { amount: 1, from: from, to: to };
+    } else {
+      const amount = parseFloat(tokens[0]);
+      let [from, to] = tokens[1]
+        .split(" TO " || " IN ")
+        .filter((s) => s !== "");
+      return { amount, from: from, to: to };
     }
-    return null;
   }
 };
 


### PR DESCRIPTION
Fixes #332 
Here:
https://github.com/felvin-search/instant-apps/blob/83b74a9506d4adf0ffa3b1c0b362cbe62a26ba35/apps/currency-convertor/src/App.jsx#L231-L234

```js
console.log(tokens);
>> ['AUSTRALIAN', 'DOLLAR', 'TO', 'RUPEE']

// when there is no amount
console.log(tokens[1]);
>> DOLLAR
```
Since it always assumes `tokens[0]` is a float value when the length is equal to 4, it takes only "Dollar" to "Rupee".
I've refactored a bit, to fix this issue with what I believe is a good solution.

| Screenshots | 
| ----------- | 
| ![image](https://user-images.githubusercontent.com/67158080/157324157-67477a81-beb9-4851-adb3-dd2d809ed8d6.png) |
![image](https://user-images.githubusercontent.com/67158080/157324251-e98c0874-a795-40c8-b9fe-04b4d6a4df2d.png) |
