### PR TITLE
update cheat.sh felvin link

### DIFF
--- a/apps/cht-sh/src/App.jsx
+++ b/apps/cht-sh/src/App.jsx
@@ -64,7 +64,7 @@ function Component({ data }) {
 
 const getSnippet = async (query) => {
   // return "Yolo"
-  const response = await fetch(`http://167.172.16.188:8002/${query}`);
+  const response = await fetch(`https://cheat-sh.felvin.com/${query}`);
   if(response.ok){
     console.log("Got output from cht.sh")
 


### PR DESCRIPTION
## Done in this PR
- Now that the cheat.sh service is deployed to https://cheat-sh.felvin.com/ , the cht-sh app makes request to it