### PR TITLE
Remove `react-json-pretty` from apps

### DIFF
--- a/apps/csv-to-json/package.json
+++ b/apps/csv-to-json/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "@felvin-search/core": "^1.56.0",
     "papaparse": "^5.3.1",
-    "react-feather": "^2.0.9",
-    "react-json-pretty": "^2.2.0"
+    "react-feather": "^2.0.9"
   },
   "devDependencies": {
     "@felvin-search/cli": "^1.59.0",

--- a/apps/csv-to-json/src/App.jsx
+++ b/apps/csv-to-json/src/App.jsx
@@ -2,7 +2,6 @@ import { Breakpoints, matchTriggerQueries } from "@felvin-search/core";
 import Papa from "papaparse";
 import React, { useEffect, useState } from "react";
 import * as Icon from "react-feather";
-import JSONPretty from "react-json-pretty";
 import styled from "styled-components";
 
 //------------Styled Components-------------
@@ -65,7 +64,7 @@ const CSVArea = styled.textarea`
   padding: 0.5rem;
 `;
 
-const JSONContainer = styled.div`
+const JSONContainer = styled.pre`
   overflow-x: scroll;
   outline: none;
 
@@ -101,7 +100,7 @@ const CopyButton = styled.button`
 //=========================================
 
 function Component() {
-  const defaultData = "FirstName,LastName\nJohn,Doe"
+  const defaultData = "FirstName,LastName\nJohn,Doe";
   const [csvData, setCSVData] = useState(defaultData);
   const [copy, setCopy] = useState(false);
   const [jsonData, setJSONData] = useState();
@@ -137,7 +136,9 @@ function Component() {
         </Column>
         <Column>
           <FormLabel htmlFor="json-pretty">Generated JSON</FormLabel>
-          <JSONContainer as={JSONPretty} id="json-pretty" data={jsonData} />
+          <JSONContainer id="json-pretty">
+            {JSON.stringify(jsonData, null, 2)}
+          </JSONContainer>
         </Column>
       </Container>
 

--- a/apps/json-formatter/package.json
+++ b/apps/json-formatter/package.json
@@ -13,8 +13,7 @@
   },
   "dependencies": {
     "@felvin-search/core": "^1.56.0",
-    "react-feather": "^2.0.9",
-    "react-json-pretty": "^2.2.0"
+    "react-feather": "^2.0.9"
   },
   "devDependencies": {
     "@felvin-search/cli": "^1.59.0",

--- a/apps/json-formatter/src/App.tsx
+++ b/apps/json-formatter/src/App.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import * as Icon from "react-feather";
-import JSONPretty from "react-json-pretty";
 import styled from "styled-components";
 import { matchTriggerQueries } from "@felvin-search/core";
 
@@ -35,7 +34,7 @@ const TextArea = styled.textarea`
   }
 `;
 
-const JSONContainer = styled.div`
+const JSONContainer = styled.pre`
   outline: none;
   padding: 0.6rem;
   margin: 1rem 0 0 0;
@@ -101,18 +100,25 @@ function Component() {
     <Container>
       <TextArea
         rows={5}
+        cols={50}
         placeholder="Paste JSON here"
-        onChange={(e) => setJsonData(e.target.value)}
+        onChange={(e) => setJsonData(JSON.parse(e.target.value))}
       />
       <FormattedJSONContainer>
         <CopyButton onClick={() => handleCopy(navigator.clipboard)}>
           {copy ? <Icon.Check /> : <Icon.Clipboard />}
         </CopyButton>
-        <JSONContainer as={JSONPretty} id="json-pretty" data={jsonData} />
+        <JSONContainer id="json-pretty">
+          {JSON.stringify(jsonData, null, 2)}
+        </JSONContainer>
       </FormattedJSONContainer>
     </Container>
   );
 }
 
-const queryToData = matchTriggerQueries(["json format", "format json", "json formatter"]);
+const queryToData = matchTriggerQueries([
+  "json format",
+  "format json",
+  "json formatter",
+]);
 export { queryToData, Component };

--- a/apps/json-to-yaml/src/App.jsx
+++ b/apps/json-to-yaml/src/App.jsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { isTriggered } from "@felvin-search/core";
 import yaml from "js-yaml";
-import JSONPretty from "react-json-pretty";
 
 //------------Styled Components-------------
 const Container = styled.div`
@@ -63,7 +62,7 @@ const JSONArea = styled.textarea`
   padding: 0.5rem;
 `;
 
-const YAMLContainer = styled.div`
+const YAMLContainer = styled.pre`
   overflow-x: scroll;
   outline: none;
 
@@ -183,7 +182,7 @@ function Component() {
         </Column>
         <Column>
           <FormLabel htmlFor="yaml-text">Generated YAML</FormLabel>
-          <YAMLContainer as={JSONPretty} id="yaml-text" data={yamlData} />
+          <YAMLContainer id="yaml-text">{yamlData}</YAMLContainer>
         </Column>
       </Container>
 

--- a/apps/yaml-to-json/src/App.jsx
+++ b/apps/yaml-to-json/src/App.jsx
@@ -1,6 +1,5 @@
 import { Breakpoints, matchTriggerQueries } from "@felvin-search/core";
 import * as Icon from "react-feather";
-import JSONPretty from "react-json-pretty";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { isTriggered } from "@felvin-search/core";
@@ -64,7 +63,7 @@ const YAMLArea = styled.textarea`
   padding: 0.5rem;
 `;
 
-const JSONContainer = styled.div`
+const JSONContainer = styled.pre`
   overflow-x: scroll;
   outline: none;
 
@@ -173,7 +172,9 @@ function Component() {
         </Column>
         <Column>
           <FormLabel htmlFor="json-pretty">Generated JSON</FormLabel>
-          <JSONContainer as={JSONPretty} id="json-pretty" data={jsonData} />
+          <JSONContainer id="json-pretty">
+            {JSON.stringify(jsonData, null, 2)}
+          </JSONContainer>
         </Column>
       </Container>
 


### PR DESCRIPTION
Fixes #319

Removed `react-json-pretty` from:
- csv-to-json
- json-formatter
- yaml-to-json
- json-to-yaml