### PR TITLE
Fix `github.repository_owner` by using single quotes instead of double quotes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   build:
-    if: github.repository_owner == "felvin-search"
+    if: github.repository_owner == 'felvin-search'
     name: Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   build:
+    if: github.repository_owner == "felvin-search"
     name: Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   main:
+    if: github.repository_owner == "felvin-search"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   main:
-    if: github.repository_owner == "felvin-search"
+    if: github.repository_owner == 'felvin-search'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-felvin-package.yml
+++ b/.github/workflows/update-felvin-package.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   main:
+    if: github.repository_owner == "felvin-search"
     runs-on: ubuntu-latest
     steps:
       - name: Pull repo, upgrade package

--- a/.github/workflows/update-felvin-package.yml
+++ b/.github/workflows/update-felvin-package.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   main:
-    if: github.repository_owner == "felvin-search"
+    if: github.repository_owner == 'felvin-search'
     runs-on: ubuntu-latest
     steps:
       - name: Pull repo, upgrade package


### PR DESCRIPTION
Fixes #374 (https://github.com/felvin-search/instant-apps/issues/374#issuecomment-1128474891)
Tested this time
![image](https://user-images.githubusercontent.com/67158080/168754511-39e817ff-cfda-43cc-b0e5-4dec14c4c69b.png)
